### PR TITLE
restore default browser from firefox-containers to chrome

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -265,7 +265,7 @@ It allows you to open multiple AWS accounts at the same time.</string>
 		<key>firefox_path</key>
 		<string>/Applications/Firefox.app/Contents/MacOS/firefox</string>
 		<key>preferred_browser</key>
-		<string>firefox-containers</string>
+		<string>chrome</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>


### PR DESCRIPTION
in #6, added support Firefox container.
But I didn't noticed to change default browser is changed.

I don't want to change a behavior of this tool. 
So I restored default browser from firefox-containers to chrome.