### PR TITLE
Fix containers instructions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When you want to use Firefox Containers, follow this instructions.
 2. Open Alfred Preference, then open Workflows.
 3. Select Open AWS via aws-vault.
 4. Select [x] icon.
-5. From Workflow Environment Variables, change preferred_browser variable from `chrome` to `firefox-container`.
+5. From Workflow Environment Variables, change preferred_browser variable from `chrome` to `firefox-containers`.
 
 ## Requirements
 


### PR DESCRIPTION
README says to set the preferred_browser variable to `firefox-container`, but the code checks for `firefox-containers`: https://github.com/kangaechu/aws-vault-alfred-workflow/blob/master/info.plist#L185

I figured updating the README is the simplest change.